### PR TITLE
feat(micronaut-gradle): enable cache write on compile task

### DIFF
--- a/.github/workflows/micronaut-gradle.yml
+++ b/.github/workflows/micronaut-gradle.yml
@@ -283,6 +283,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false
 
       - name: Compile source and test code
         shell: bash


### PR DESCRIPTION
L'idée est de cacher la compilation, pour ne pas recompiler dans le step unit-test et e2e-test. Ça pourrait avoir un side-effect sur la taille de la cache donc peut-être que certaines caches vont faire un miss sur main ensuite, ce serait à surveiller.