### PR TITLE
PHP Sdk now generated for php 8.1

### DIFF
--- a/.github/workflows/micronaut-gradle.yml
+++ b/.github/workflows/micronaut-gradle.yml
@@ -615,7 +615,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         if: matrix.generator == 'php'
         with:
-          php-version: "7.4"
+          php-version: "8.1"
 
       - name: Generate SDK
         uses: equisoft-actions/generate-openapi-sdk@v2


### PR DESCRIPTION
Le minimum requis pour les sdk php est maintenant à 8.1

J'aurais pu prendre le input `php-version` mais c'est plus pour la version php du projet lui même (dans le setup hybride qui exisste plus pour billing).

Je garde 8.1 pour builder pour avoir 100% de chance d'être compatible avec ce qui est écrit dans le composer.json des sdk.

Par contre, le workflow php build avec la version du workflow (8.3 bientôt 8.4), je pense que c'est pas si grave.